### PR TITLE
Send progress

### DIFF
--- a/src/go/wormhole/client.ts
+++ b/src/go/wormhole/client.ts
@@ -1,4 +1,4 @@
-import {ClientConfig, wormhole} from "@/go/wormhole/types";
+import {ClientConfig, ProgressCallback, wormhole} from "@/go/wormhole/types";
 
 const DEFAULT_PROD_CLIENT_CONFIG: ClientConfig = {
     // rendezvousURL: "wss://relay.magic-wormhole.io:4000/v1",
@@ -23,9 +23,9 @@ export default class Client {
         return wormhole.Client.sendText(this.goClient, message);
     }
 
-    public async sendFile(file: File): Promise<string> {
+    public async sendFile(file: File, progressCb?: ProgressCallback): Promise<string> {
         const data = new Uint8Array(await file.arrayBuffer());
-        return wormhole.Client.sendFile(this.goClient, file.name, data);
+        return wormhole.Client.sendFile(this.goClient, file.name, data, progressCb);
     }
 
     public async recvText(code: string): Promise<string> {

--- a/src/go/wormhole/types.ts
+++ b/src/go/wormhole/types.ts
@@ -5,11 +5,13 @@ export interface WindowWormhole {
 export interface WindowClient {
     newClient(config?: ClientConfig): number;
     sendText(goClient: number, message: string): Promise<string>;
-    sendFile(goClient: number, fileName: string, fileData: Uint8Array): Promise<string>;
+    sendFile(goClient: number, fileName: string, fileData: Uint8Array, progressCb?: ProgressCallback): Promise<string>;
     recvText(goClient: number, code: string): Promise<string>;
     recvFile(goClient: number, code: string): Promise<Uint8Array>;
     free(goClient: number): string | undefined;
 }
+
+export type ProgressCallback = (sentBytes: number, totalBytes: number) => void
 
 export interface ClientConfig {
     rendezvousURL: string;

--- a/tests/unit/progress.spec.ts
+++ b/tests/unit/progress.spec.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+import Go from "@/go";
+import Client from '@/go/wormhole/client'
+
+async function initGo() {
+    const go = new Go();
+    const wasmPath = path.join(__dirname, '..', '..', 'public', 'assets', 'wormhole.wasm');
+    await WebAssembly.instantiate(fs.readFileSync(wasmPath), go.importObject).then((result) => {
+        go.run(result.instance);
+    });
+}
+
+describe('Send progress', () => {
+    beforeAll(initGo)
+
+    it('increments from 0 to total size', async () => {
+        const sender = new Client()
+        const data = 'testing 123'
+
+        const progressCb = jest.fn()
+
+        const file = {
+            arrayBuffer() {
+                const enc = new TextEncoder();
+                return enc.encode(data);
+            }
+        }
+
+        const code = await sender.sendFile(file, (sentBytes: number, totalBytes: number) => {
+            progressCb(sentBytes, totalBytes);
+        })
+
+        const receiver = new Client();
+        await receiver.recvFile(code);
+        expect(progressCb).toHaveBeenCalled();
+    })
+})
+
+async function mockSend(name: string, data: string): Promise<string> {
+    const sender = new Client();
+    const file = {
+        arrayBuffer() {
+            const enc = new TextEncoder();
+            return enc.encode(data);
+        }
+    }
+    return await sender.sendFile(file);
+}


### PR DESCRIPTION
Adds test coverage over the send progress callback passed to the `Client#SendFile` wrapper function (see [this diff](https://github.com/LeastAuthority/wormhole-william/compare/websocket-relay...LeastAuthority:progress?expand=1#diff-2d9d67027ab40e0e41055ef3230db2acde677f63c80c94e0c5e00457ed56bcd9R114)).