### PR TITLE
Add file size limit and corresponding alert

### DIFF
--- a/src/components/receive/ReceiveConsent.vue
+++ b/src/components/receive/ReceiveConsent.vue
@@ -77,7 +77,7 @@ import {enterOutline, exitOutline, exit, cloudDownloadOutline, close} from 'ioni
 import router from '@/router/index.ts'
 import {
     ACCEPT_FILE,
-    ALERT,
+    ALERT_MATCHED_ERROR,
     NEW_CLIENT,
     RESET_CODE,
     RESET_PROGRESS,
@@ -102,7 +102,7 @@ export default defineComponent({
         ...mapState(['config', 'code', 'fileMeta', 'progress']),
     },
     methods: {
-        ...mapActions([ACCEPT_FILE, ALERT]),
+        ...mapActions([ACCEPT_FILE, ALERT_MATCHED_ERROR]),
         ...mapMutations([SET_PROGRESS, RESET_CODE, RESET_PROGRESS]),
         async download() {
             this.next();

--- a/src/components/receive/ReceiveDefault.vue
+++ b/src/components/receive/ReceiveDefault.vue
@@ -107,7 +107,7 @@ import {
     IonText
 } from "@ionic/vue";
 import {mapActions, mapMutations, mapState} from "vuex";
-import {ALERT, SAVE_FILE, SET_CODE} from "@/store/actions";
+import {ALERT_MATCHED_ERROR, SAVE_FILE, SET_CODE} from "@/store/actions";
 import {defineComponent} from "vue";
 import WaitButton, {DefaultDuration} from "@/components/WaitButton.vue";
 import {ErrBadCode, ErrInvalidCode} from "@/errors";
@@ -147,7 +147,7 @@ export default defineComponent({
         }
     },
     methods: {
-        ...mapActions([SAVE_FILE, ALERT]),
+        ...mapActions([SAVE_FILE, ALERT_MATCHED_ERROR]),
         ...mapMutations([SET_CODE]),
         _setCode(code: string): void {
             this[SET_CODE](code);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -29,6 +29,7 @@ export const RESET_PROGRESS = 'reset_progress';
 export const NEXT_STEP = 'next_step';
 export const UPDATE_PROGRESS_ETA = 'update_progress_eta';
 export const ALERT = 'alert';
+export const ALERT_MATCHED_ERROR = 'alert_matched_error';
 
 export interface RPCMessage {
     id: number;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,7 +2,7 @@ import {Action, ActionContext, createStore, Module, Store} from 'vuex'
 import {ClientConfig, TransferOptions, TransferProgress} from "@/go/wormhole/types";
 import {DEFAULT_PROD_CLIENT_CONFIG} from "@/go/wormhole/client";
 import {
-    ACCEPT_FILE, ALERT,
+    ACCEPT_FILE, ALERT, ALERT_MATCHED_ERROR,
     NEW_CLIENT,
     RESET_CODE,
     RESET_PROGRESS,
@@ -97,12 +97,12 @@ async function sendFileAction(this: Store<any>, {
             // TODO: remove!
             // dispatch(NEW_CLIENT);
         }).catch(error => {
-            dispatch(ALERT, {error})
+            dispatch(ALERT_MATCHED_ERROR, {error})
             return Promise.reject(error);
         });
         // return done;
     }).catch((error) => {
-        dispatch(ALERT, {error})
+        dispatch(ALERT_MATCHED_ERROR, {error})
         return Promise.reject(error);
     });
     return p;
@@ -143,12 +143,12 @@ async function saveFileAction(this: Store<any>, {
                 commit(RESET_CODE);
                 commit(RESET_PROGRESS);
             }).catch((error: string) => {
-                dispatch(ALERT, {error});
+                dispatch(ALERT_MATCHED_ERROR, {error});
                 return Promise.reject(error);
             });
         })
         .catch((error: string) => {
-            dispatch(ALERT, {error});
+            dispatch(ALERT_MATCHED_ERROR, {error});
             return Promise.reject(error);
         });
     return p;
@@ -176,7 +176,7 @@ function updateProgressETAAction(this: Store<any>, {state, commit}: ActionContex
 async function acceptFileAction(this: Store<any>, {state, dispatch}: ActionContext<any, any>): Promise<void> {
     const p = state.fileMeta.accept()
     p.catch((error: string) => {
-        dispatch(ALERT, {error});
+        dispatch(ALERT_MATCHED_ERROR, {error});
     });
     return p;
 }
@@ -187,7 +187,16 @@ declare interface AlertPayload {
     opts?: AlertOptions;
 }
 
-async function alertAction(this: Store<any>, {state}: ActionContext<any, any>, payload: AlertPayload): Promise<void> {
+async function alertAction(this: Store<any>, ctx: ActionContext<any, any>, alertOpts: AlertOptions): Promise<void> {
+    const alert = await alertController.create(alertOpts);
+    await alert.present();
+    await alert.onWillDismiss();
+}
+
+async function alertMatchedErrorAction(this: Store<any>, {
+    state,
+    dispatch
+}: ActionContext<any, any>, payload: AlertPayload): Promise<void> {
     // TODO: types!
     // NB: error is a string
     const {error} = payload;
@@ -211,9 +220,7 @@ async function alertAction(this: Store<any>, {state}: ActionContext<any, any>, p
         opts.message = (error);
     }
 
-    const alert = await alertController.create(opts);
-    await alert.present();
-    await alert.onWillDismiss();
+    return dispatch(ALERT, opts);
 }
 
 /* --- MUTATIONS --- */
@@ -329,6 +336,7 @@ export default createStore({
         [ACCEPT_FILE]: acceptFileAction,
         [UPDATE_PROGRESS_ETA]: updateProgressETAAction,
         [ALERT]: alertAction,
+        [ALERT_MATCHED_ERROR]: alertMatchedErrorAction,
     },
     getters: {
         progressETA: ({progress, progressETASeconds}) => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -19,6 +19,9 @@ import {AlertOptions} from "@ionic/core";
 import {ErrRelay, ErrMailbox, ErrInterrupt, ErrBadCode, MatchableErrors} from "@/errors";
 import {durationToClosesUnit, sizeToClosestUnit} from "@/util";
 
+const MAX_FILE_SIZE_MB = 200;
+const MB = 1000 ** 2;
+const MAX_FILE_SIZE_BYTES = MB * MAX_FILE_SIZE_MB;
 const updateProgressETAFrequency = 10;
 const defaultAlertOpts: AlertOptions = {
     buttons: ['OK'],
@@ -69,6 +72,18 @@ async function sendFileAction(this: Store<any>, {
 }: ActionContext<any, any>, {file, opts}: SendFilePayload): Promise<TransferProgress> {
     // NB: reset code
     commit(SET_CODE, '');
+
+    if (opts?.size && opts?.size > MAX_FILE_SIZE_BYTES) {
+        const alertOpts: AlertOptions = {
+            subHeader: 'Large file sizes: coming soon',
+            message: `In this development state, this product only supports file sizes of up to ${MAX_FILE_SIZE_MB} MB.
+Please select a smaller file.`,
+            buttons: [{
+                text: 'OK'
+            }],
+        };
+        return dispatch(ALERT, alertOpts);
+    }
 
     const progressFunc = (sentBytes: number, totalBytes: number) => {
         commit(SET_PROGRESS, sentBytes / totalBytes);

--- a/src/views/Receive.vue
+++ b/src/views/Receive.vue
@@ -40,7 +40,7 @@ import ReceiveDefault from "@/components/receive/ReceiveDefault.vue";
 import ReceiveConsent from "@/components/receive/ReceiveConsent.vue";
 import ReceiveComplete from "@/components/receive/ReceiveComplete.vue";
 import {ReceiveStep} from "@/types";
-import {ALERT, RESET_PROGRESS, SAVE_FILE, SET_CODE, SET_FILE_META, SET_PROGRESS} from "@/store/actions";
+import {ALERT_MATCHED_ERROR, RESET_PROGRESS, SAVE_FILE, SET_CODE, SET_FILE_META, SET_PROGRESS} from "@/store/actions";
 import {mapActions, mapMutations, mapState} from "vuex";
 import ReceiveProgress from "@/components/receive/ReceiveProgress.vue";
 
@@ -67,7 +67,7 @@ export default defineComponent({
         ...mapState(['code']),
     },
     methods: {
-        ...mapActions([SAVE_FILE, ALERT]),
+        ...mapActions([SAVE_FILE, ALERT_MATCHED_ERROR]),
         ...mapMutations([SET_FILE_META, RESET_PROGRESS]),
         onStep(step: ReceiveStep): boolean {
             return this.step === step;

--- a/src/views/Send.vue
+++ b/src/views/Send.vue
@@ -114,7 +114,10 @@ export default defineComponent({
         // TODO: refactor.
         async sendFile(): Promise<void> {
             const progressNext = this.nextFrom(SendStep.Instructions);
-            const opts = {progressFunc: progressNext};
+            const opts = {
+                progressFunc: progressNext,
+                size: this.file?.size,
+            };
             const payload = {file: this.file, opts};
             const p = this[SEND_FILE](payload);
             this.step = SendStep.Instructions;


### PR DESCRIPTION
Adds a maximum file size and sets it to 200 megabytes. If a user selects a file which is larger than this, an error alert modal is shown with a single "OK" button. Clicking or tapping on the modal backdrop also dismisses the dialog. 

_(The app returns to the select default screen when the modal is dismissed)_

---

## Code Review Checklist (to be filled out by reviewer)

- [X] Description accurately reflects what changes are being made.
- [X] Description explains why the changes are being made (or references an issue containing one).
- [X] The PR appropriately sized.
~~- [ ] New code has enough tests.~~
~~- [ ] New code has enough documentation to answer "how do I use it?" and "what does it do?".~~
~~- [ ] Existing documentation is up-to-date, if impacted.~~
